### PR TITLE
Use correct input name for run args

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.patterns }}
+    - ${{ inputs.pattern }}
 branding:
   icon: bell
   color: green


### PR DESCRIPTION
"pattern" was defined, but the "runs" section used "patterns" instead.

See #4.