### PR TITLE
test: run current revision instead of v1 tag

### DIFF
--- a/.github/workflows/oktest.yml
+++ b/.github/workflows/oktest.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: json-syntax-check
-        uses: limitusus/json-syntax-check@v1
+        uses: ./
         with:
           pattern: "ok_[0-9]+\\.json$"


### PR DESCRIPTION
The current test action in this repo always runs the `v1` tag. Even if that tag was kept up to date (it hasn't been), it's not particularly useful to always run a known-good revision of the action as a test.

Having the step use `./` instead makes it use the repo itself, thereby always testing the current revision.