### PR TITLE
BASE defaults to `$GITHUB_WORKSPACE` instead of `/data/`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2
 LABEL maintainer "Tomoya Kabe <limit.usus@gmail.com>"
 
-ENV BASE=/data/
+ENV BASE=/github/workspace
 ENV DEBUG=0
 
 RUN mkdir -p /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:2
 LABEL maintainer "Tomoya Kabe <limit.usus@gmail.com>"
 
-ENV BASE=/github/workspace
 ENV DEBUG=0
 
 RUN mkdir -p /data

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Simple JSON syntax checker
 
 **Required** file pattern to check syntax. Default is `'\\.json$'`.
 
+## Environment variables
+
+### `BASE`
+
+*Optional* base directory in which to look for files matching `pattern`.
+
+If `BASE` is not set, json-syntax-check will look in `GITHUB_WORKSPACE`.
+
 ## Outputs
 
 ### `failed_files`

--- a/json_syntax_check
+++ b/json_syntax_check
@@ -28,7 +28,7 @@ class Checker
   def initialize(patterns)
     @patterns = patterns.map { |pat| Regexp.compile(pat) }
     @files = nil
-    @base = ENV.fetch('BASE', '/github/workspace')
+    @base = ENV.fetch('BASE', ENV.fetch('GITHUB_WORKSPACE'))
     @debug = ENV.fetch('DEBUG', '0') != '0'
   end
 

--- a/json_syntax_check
+++ b/json_syntax_check
@@ -28,7 +28,7 @@ class Checker
   def initialize(patterns)
     @patterns = patterns.map { |pat| Regexp.compile(pat) }
     @files = nil
-    @base = ENV.fetch('BASE', '/data/')
+    @base = ENV.fetch('BASE', '/github/workspace')
     @debug = ENV.fetch('DEBUG', '0') != '0'
   end
 


### PR DESCRIPTION
The actions/checkout action puts the repo in `/github/workspace`, and that's where this action should look for JSON files by default. This is the other half of what I was talking about in #4 regarding default behavior.