### PR TITLE
Include `JSON::ParserError` message in failure output

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,8 @@
+AllCops:
+  NewCops: enable
+
 Metrics/MethodLength:
+  Max: 20
+
+Metrics/AbcSize:
   Max: 20

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-# gem "rails"
+gem 'rubocop', '~> 1.4', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,32 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.1)
+    parallel (1.20.1)
+    parser (2.7.2.0)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
+    regexp_parser (2.0.0)
+    rexml (3.2.4)
+    rubocop (1.4.2)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8)
+      rexml
+      rubocop-ast (>= 1.1.1)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.2.0)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  rubocop (~> 1.4)
 
 BUNDLED WITH
    2.1.4

--- a/json_syntax_check
+++ b/json_syntax_check
@@ -10,17 +10,26 @@ module JSONChecker
     patterns = argv
     checker = Checker.new(patterns)
     failures = checker.run
-    failed_files = failures.map{|entry| entry[0]}.compact
-    puts "::set-output name=failed_files::#{JSON.dump(failed_files)}"
+    puts "::set-output name=failed_files::#{JSON.dump(failures.map(&:file))}"
     if !failures.empty?
       puts "Files below has/have JSON syntax error (of #{checker.files.length} files)"
-      failures.each do |f, h|
-        puts "- #{f}: #{h}"
+      failures.each do |f|
+        puts "- #{f.file}: #{f.hint}"
       end
     else
       puts "No file has JSON syntax error (of #{checker.files.length} files)"
     end
     failures.length
+  end
+end
+
+# Syntax failure
+class Failure
+  attr_reader :file, :hint
+
+  def initialize(file, hint)
+    @file = file
+    @hint = hint
   end
 end
 
@@ -50,29 +59,20 @@ class Checker
   end
 
   def run
-    failures = []
-    files.each do |file|
-      file, hint = valid_json(file)
-      if hint
-        failures << [file, hint]
-      end
-    end
-    failures
+    failures = files.map { |f| validate_json(f) }
+    failures.compact
   end
 
-  def valid_json(file)
-    begin
-      JSON.parse(File.read(file))
-    rescue JSON::ParserError => err
-      hint = err.message.lines.first.chomp unless err.message.lines.nil?
-      if err.message.lines.length > 1
-        hint += "' ..."
-      end
-      hint ||= 'Unknown JSON parse error'
-      return file, hint
-    else
-      return file, nil
-    end
+  def validate_json(file)
+    JSON.parse(File.read(file))
+  rescue JSON::ParserError => e
+    hint = e.message.lines.first.chomp unless e.message.lines.nil?
+    hint += "' ..." if e.message.lines.length > 1
+
+    hint ||= 'Unknown JSON parse error'
+    Failure.new(file, hint)
+  else
+    nil
   end
 end
 

--- a/json_syntax_check
+++ b/json_syntax_check
@@ -11,13 +11,13 @@ module JSONChecker
     checker = Checker.new(patterns)
     failures = checker.run
     puts "::set-output name=failed_files::#{JSON.dump(failures.map(&:file))}"
-    if !failures.empty?
+    if failures.empty?
+      puts "No file has JSON syntax error (of #{checker.files.length} files)"
+    else
       puts "Files below has/have JSON syntax error (of #{checker.files.length} files)"
       failures.each do |f|
         puts "- #{f.file}: #{f.hint}"
       end
-    else
-      puts "No file has JSON syntax error (of #{checker.files.length} files)"
     end
     failures.length
   end

--- a/json_syntax_check
+++ b/json_syntax_check
@@ -10,11 +10,12 @@ module JSONChecker
     patterns = argv
     checker = Checker.new(patterns)
     failures = checker.run
-    puts "::set-output name=failed_files::#{JSON.dump(failures)}"
+    failed_files = failures.map{|entry| entry[0]}.compact
+    puts "::set-output name=failed_files::#{JSON.dump(failed_files)}"
     if !failures.empty?
       puts "Files below has/have JSON syntax error (of #{checker.files.length} files)"
-      failures.each do |f|
-        puts "- #{f}"
+      failures.each do |f, h|
+        puts "- #{f}: #{h}"
       end
     else
       puts "No file has JSON syntax error (of #{checker.files.length} files)"
@@ -51,16 +52,27 @@ class Checker
   def run
     failures = []
     files.each do |file|
-      failures << file unless valid_json?(file)
+      file, hint = valid_json(file)
+      if hint
+        failures << [file, hint]
+      end
     end
     failures
   end
 
-  def valid_json?(file)
-    JSON.parse(File.read(file))
-    true
-  rescue JSON::ParserError
-    false
+  def valid_json(file)
+    begin
+      JSON.parse(File.read(file))
+    rescue JSON::ParserError => err
+      hint = err.message.lines.first.chomp unless err.message.lines.nil?
+      if err.message.lines.length > 1
+        hint += "' ..."
+      end
+      hint ||= 'Unknown JSON parse error'
+      return file, hint
+    else
+      return file, nil
+    end
   end
 end
 


### PR DESCRIPTION
Doesn't give a line number, but it's still helpful context.

Preserves the original `::set-output` behavior that lists only filenames, in case there are workflows out there that use this action's output for further steps.

Please let me know if I've done anything the "wrong" way. This is one of the first things I've ever tried to do in Ruby, so there must be some "noob" pattern I used that an experienced Ruby dev wouldn't write. 😸